### PR TITLE
Specifying templates in PackageLoader(), adding jinja2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
     "pandas",
     "scikit-image",
     "xarray",
+    "jinja2"
 ]
 
 [project.urls]

--- a/src/asli/asli.py
+++ b/src/asli/asli.py
@@ -288,7 +288,7 @@ class ASLICalculator:
         # Set up jinja
         from jinja2 import Environment, PackageLoader, select_autoescape
 
-        env = Environment(loader=PackageLoader("asli"), autoescape=select_autoescape())
+        env = Environment(loader=PackageLoader("asli", "templates"), autoescape=select_autoescape())
         template = env.get_template("asli_data.csv.template")
 
         header = template.render(


### PR DESCRIPTION
Adding jinja2 as a dependency, referring to templates in PackageLoader()

Closes #4 and #5