### PR TITLE
explicitly include template file

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,12 @@ dependencies = [
     "jinja2"
 ]
 
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[tool.setuptools.package-data]
+asli = ["templates/asli_data.csv.template"]
+
 [project.urls]
 Source = "https://github.com/scotthosking/amundsen-sea-low-index"
 Bug_Tracker = "https://github.com/scotthosking/amundsen-sea-low-index/issues"

--- a/src/asli/asli.py
+++ b/src/asli/asli.py
@@ -288,7 +288,7 @@ class ASLICalculator:
         # Set up jinja
         from jinja2 import Environment, PackageLoader, select_autoescape
 
-        env = Environment(loader=PackageLoader("asli", "templates"), autoescape=select_autoescape())
+        env = Environment(loader=PackageLoader("asli"), autoescape=select_autoescape())
         template = env.get_template("asli_data.csv.template")
 
         header = template.render(


### PR DESCRIPTION
This is one of the options for including what are known as "data files" in the python packaging world apparently: https://setuptools.pypa.io/en/latest/userguide/datafiles.html

I haven't run the code but pip installing it (to `site-packages`, not as an editable) results in the templates dir and template file being included.