### PR TITLE
Separate plotting from calculation

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,19 @@ Basic plots of the pressure fields and lows can be made using the `plot_region_a
 a.plot_region_all()
 ```
 
+Optionally, calculations already saved to file can be read back in to a new `ASLCalculator` object with its `import_from_csv()` method, for instance in a new session, for plotting. Note that to plot from a new object, the `read_mask_data()` and `read_msl_data()` (or just `read_data()`) methods will need to be run first, for example:
+
+```
+import asli
+b = asli.ASLICalculator(data_dir="./data/", 
+                   mask_filename="era5_lsm.nc",
+                   msl_pattern="ERA5/monthly/era5_mean_sea_level_pressure_monthly_1988.nc"
+                   )
+b.read_data()
+b.import_from_csv('asl.csv')
+b.plot_region_all()
+```
+
 ### Getting help
 Most of the package has docstrings in the source code, so try running `help()` on any of the functions, classes or their methods, e.g. `help(asli.ASLICalculator)`.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,4 +55,5 @@ dev = [
 [project.scripts]
 asli_data_lsm = "asli:data._cli_get_land_sea_mask"
 asli_data_era5 = "asli:data._cli_get_era5_monthly"
-asli_calc = "asli:asli.main"
+asli_calc = "asli:asli._cli_calc"
+asli_plot = "asli:asli._cli_plot"

--- a/src/asli/asli.py
+++ b/src/asli/asli.py
@@ -300,7 +300,7 @@ class ASLICalculator:
             data_version=datetime.datetime.now().strftime("%Y%m%d"),
         )
 
-        logger.info(f"Writing csv to {f}")
+        logger.info(f"Writing csv to {filepath}")
         with open(filepath, "w") as f:
             f.writelines(header)
             self.asl_df.to_csv(f, index=False)

--- a/src/asli/asli.py
+++ b/src/asli/asli.py
@@ -307,6 +307,10 @@ class ASLICalculator:
 
     def plot_region_all(self):
         """Plots mean sea level pressure fields for the Amundsen Sea with identified low pressure and bounding box."""
+
+        if self.asl_df is None:
+            raise Warning(f"ASL calculation dataframe is {self.as_df}, can not plot. \
+                          Try running .calculate() first.")
         plot_lows(self.masked_msl_data, self.asl_df, regionbox=ASL_REGION)
 
     def plot_region_year(self, year: int):
@@ -315,6 +319,10 @@ class ASLICalculator:
         Args:
             year (int): year to plot
         """
+        if self.asl_df is None:
+            raise Warning(f"ASL calculation dataframe is {self.as_df}, can not plot. \
+                          Try running .calculate() first.")
+        
         da = self.masked_msl_data.sel(
             time=slice(str(year) + "-01-01", str(year) + "-12-01")
         )

--- a/src/asli/asli.py
+++ b/src/asli/asli.py
@@ -270,7 +270,7 @@ class ASLICalculator:
         """Writes out ASLICalculator.asl_df as a CSV file with header.
 
         Args:
-            filename (str): filename to write out to.
+            filename (str): filename to write out to, relative to "data_dir".
         """
 
         filepath = Path(self.data_dir, filename)
@@ -297,6 +297,7 @@ class ASLICalculator:
             data_version=datetime.datetime.now().strftime("%Y%m%d"),
         )
 
+        logger.info(f"Writing csv to {f}")
         with open(filepath, "w") as f:
             f.writelines(header)
             self.asl_df.to_csv(f, index=False)

--- a/src/asli/asli.py
+++ b/src/asli/asli.py
@@ -240,11 +240,14 @@ class ASLICalculator:
         From loaded mean sea level pressure data and land-sea mask, runs the calculation of minima.
 
         Args:
-            n_jobs (int, optional): Number of processes to use for parallel caclulation. Defaults to 1.
+            n_jobs (int, optional): Number of processes to use for parallel calculation. Defaults to 1.
 
         Returns:
-            pd.DataFrame: dataframe containing locations of pressure minima, mean pressure
+            pd.DataFrame: dataframe containing locations of pressure minima, mean pressure.
         """
+
+        if self.sliced_msl is None:
+            raise Exception(f"self.sliced_msl is {self.sliced_msl}, have you run .read_data()?")
 
         if "season" in self.sliced_msl.dims:
             ntime = 4

--- a/src/asli/asli.py
+++ b/src/asli/asli.py
@@ -305,6 +305,26 @@ class ASLICalculator:
             f.writelines(header)
             self.asl_df.to_csv(f, index=False)
 
+
+    def import_from_csv(self, filename: (str|Path),force: bool = False):
+        """
+        Import a csv file exported from the .export_df method, for example to plot data from a previous session.
+
+        Args:
+            filename (str|Path, required): Path to csv file containing ASL dataframe.
+            force (bool, optional): Overwrite existing calculations in this object. Defaults to False.
+        """
+
+        if self.asl_df is not None and not force:
+            logger.warn("Calculation dataframe has existing values, set force=True to overwrite with import.")
+            return
+        
+        filepath = Path(self.data_dir, filename)
+        
+        logger.info(f"Importing ASL values from {filepath}")
+        self.asl_df = pd.read_csv(filepath, header=27)
+
+
     def plot_region_all(self):
         """Plots mean sea level pressure fields for the Amundsen Sea with identified low pressure and bounding box."""
 

--- a/src/asli/templates/asli_data.csv.template
+++ b/src/asli/templates/asli_data.csv.template
@@ -27,4 +27,3 @@
 # 
 # 
 
-time,lon,lat,ActCenPres,SectorPres,RelCenPres


### PR DESCRIPTION
Resolves #8 
Resolves #9 

This PR separates plotting from calculation by adding the option to read in calculations from a csv file, effectively permitting skipping the calculation step.

I've opted to use the existing `to_csv()` method rather than add another one and have added a method to import from that csv.


To do:
+ [x] add some docs on this usage to readme,
+ [x] add a cli to this usage

Questions for @thomaszwagerman 
+ Do we want plotting to be an option in the `asli_calc` command?
+ How many plot options do we need in general and in the `asli_plot` command?
  + write out the file - probably yes, it's not in there yet
  + set time bounds on the plotting?
  + option to just plot a single month?
  + anything else?