### PR TITLE
Handle interim ERA5 data (ERA5T)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ classifiers = [
 ]
 requires-python = ">=3.9"
 dependencies = [
-    "cdsapi>0.7",
+    "cdsapi>=0.7.0",
     "cartopy",
     "dask",
     "joblib",

--- a/src/asli/asli.py
+++ b/src/asli/asli.py
@@ -92,12 +92,13 @@ def get_lows(da: xr.DataArray, mask: xr.DataArray) -> pd.DataFrame:
     df["ActCenPres"] = pressure
     df["SectorPres"] = sector_mean_pres
     df["time"] = time_str
+    df["interim"] = True if da.expver.values == "0005" else False
 
     ### Add relative central pressure (Hosking et al. 2013)
     df["RelCenPres"] = df["ActCenPres"] - df["SectorPres"]
 
     ### re-order columns
-    df = df[["time", "lon", "lat", "ActCenPres", "SectorPres", "RelCenPres"]]
+    df = df[["time", "lon", "lat", "ActCenPres", "SectorPres", "RelCenPres", "interim"]]
 
     ### clean-up DataFrame
     df = df.reset_index(drop=True)


### PR DESCRIPTION
Resolves #10 

This makes use of the `expver` flag which is now included in the CDS beta and now seems to be included in all downloads (not just those with mixtures of ERA5/ERA5T data).

Adds a column "interim" to the data output to indicate whether each month was calculated with ERA5T data or not.

Adds a flag (`-i`/`--interim`) to the CLI `asli_calc` to turn on the inclusion of interim data.