### PR TITLE
add equals to for cdsapi version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ classifiers = [
 ]
 requires-python = ">=3.9"
 dependencies = [
-    "cdsapi>0.7",
+    "cdsapi>=0.7",
     "cartopy",
     "dask",
     "joblib",


### PR DESCRIPTION
Current cdsapi version is 0.7.0, this dependency could not be installed with >=0.7