### PR TITLE
Raise warning when expver not available; fix expver/masking bug

### DIFF
--- a/src/asli/asli.py
+++ b/src/asli/asli.py
@@ -102,7 +102,15 @@ def get_lows(
     df["actual_central_pressure"] = pressure
     df["sector_pressure"] = sector_mean_pres
     df["time"] = time_str
-    df["DataSource"] = "ERA5T" if da.expver.values == "0005" else "ERA5"
+
+    if hasattr(da, "expver"):
+        df["DataSource"] = "ERA5T" if da.expver.values == "0005" else "ERA5"
+    else:
+        logger.warning(
+            f"Cannot determine DataSource for {time_str}. Setting DataSource to UNKNOWN for this row."
+        )
+        df["DataSource"] = "UNKNOWN"
+        logger.debug(da)
 
     ### Add relative central pressure (Hosking et al. 2013)
     df["relative_central_pressure"] = (

--- a/src/asli/asli.py
+++ b/src/asli/asli.py
@@ -69,6 +69,9 @@ def get_lows(
     datetime_values = pd.to_datetime(da.valid_time.values)
     time_str = datetime_values.strftime("%Y-%m-%d")
 
+    # ensure that expver value of mask doesn't impact masking
+    mask = mask.reset_coords("expver", drop=True)
+
     # fill land in with highest value to limit lows being found here
     da_max = da.max().values
     da = da.where(mask < MASK_THRESHOLD).fillna(da_max)

--- a/src/asli/asli.py
+++ b/src/asli/asli.py
@@ -107,7 +107,12 @@ def get_lows(
     df["time"] = time_str
 
     if hasattr(da, "expver"):
-        df["DataSource"] = "ERA5T" if da.expver.values == "0005" else "ERA5"
+        if da.expver.values == "0001":
+            df["DataSource"] = "ERA5"
+        elif da.expver.values == "0005":
+            df["DataSource"] = "ERA5T"
+        else:
+            df["DataSource"] = str(da.expver.values)
     else:
         logger.warning(
             f"Cannot determine DataSource for {time_str}. Setting DataSource to UNKNOWN for this row."


### PR DESCRIPTION
Took me a while, but I found a bug where the mask data now has a value of expver (which I guess it didn't used to, since the issue we raised with ECMWF (see below) resulted in expver always being included) - this was causing the masking step to remove the expver value of the monthly dataset if it didn't match the mask's, e.g. mask.expver = '0001' and da.expver = '0005'.

Have also added a warning and a catch if the da ends up with no expver value.



<details>

<summary>🦆 Now irrelevant thoughts on this from before I worked out the issue, kept for posterity.</summary>

I can no longer remember the subtleties of the ERA5/ERA5T/expver issue from the changes to the CDS api.

From the ECMWF Confluence (https://confluence.ecmwf.int/display/CKB/ERA5%3A+data+documentation)
> For netCDF data requests which return just ERA5 or just ERA5T data, there is no means of differentiating between ERA5 and ERA5T data in the resulting netCDF files.
> 
> For netCDF data requests which return a mixture of ERA5 and ERA5T data, the origin of the variables (1 or 5) will be identifiable in the resulting netCDF files

So once again we're apparently in a position where downloading a dataset without a mixture of ERA5/ERA5T then we can't apparently determine the datasource.

What's made me try to fix this is downloading a dataset from Jan 2024 to Jan 2026, where all months have expver='0001' except the last month (Jan 2026) which doesn't have a value of expver at all, which makes no sense to me since the downloaded dataset **_does_** have a mixture of ERA5/ERA5T.

@thomaszwagerman I seem to remember you raising this with CDS/Copernicus/ECMWF, found it, response from 6/8/24:

> This issue with expver has now been fixed with expver now showing as an extra coordinate in the NetCDF file:
>
>                string tp:coordinates = "number valid_time latitude longitude expver" ;
>
>Also note that an additional key ('download_format') has been introduced to better define the output file format. See for example at https://cds-beta.climate.copernicus.eu/datasets/reanalysis-era5-single-levels?tab=download  
>
>As mentioned on our [informative page](https://confluence.ecmwf.int/x/uINmFw), a new GRIB to NetCDF convertor has been implemented in CDS-Beta. We are working on some documentation for this and will post an announcement as soon as possible on our [Forum](https://forum.ecmwf.int/).

</details>